### PR TITLE
fix teleporting to lift destination coordinates when changing worlds while lift is active

### DIFF
--- a/src/main/java/com/minecraftcorp/lift/bukkit/listener/PlayerListener.java
+++ b/src/main/java/com/minecraftcorp/lift/bukkit/listener/PlayerListener.java
@@ -175,19 +175,13 @@ public class PlayerListener implements Listener {
 			return;
 		}
 
-		BukkitElevator elevator = plugin.getActiveLifts()
+		plugin.getActiveLifts()
 				.stream()
-				.findFirst()
-				.orElse(null);
-
-		if (elevator == null) {
-			return;
-		}
-
-		plugin.logDebug(player.getName() + " changed a world while lifting.");
-
-		elevator.removePassengers(Collections.singletonList(player));
-		elevator.removeFreezers(Collections.singletonList(player));
+				.filter(elevator -> elevator.getPassengers().contains(player) || elevator.getFreezers().contains(player))
+				.forEach(elevator -> {
+					elevator.removePassengers(Collections.singletonList(player));
+					elevator.removeFreezers(Collections.singletonList(player));
+				});
 
 		player.teleport(playerLocation, PlayerTeleportEvent.TeleportCause.PLUGIN);
 		ElevatorExecutor.resetEntityPhysics(player);

--- a/src/main/java/com/minecraftcorp/lift/bukkit/listener/PlayerListener.java
+++ b/src/main/java/com/minecraftcorp/lift/bukkit/listener/PlayerListener.java
@@ -164,6 +164,35 @@ public class PlayerListener implements Listener {
 		player.setVelocity(pushBack);
 	}
 
+	@EventHandler
+	public void onPlayerChangedWorldEvent(PlayerChangedWorldEvent event) {
+		Player player = event.getPlayer();
+		Location playerLocation = player.getLocation();
+
+		boolean playerInNoLift = plugin.isInNoLift(player.getUniqueId());
+
+		if (playerInNoLift) {
+			return;
+		}
+
+		BukkitElevator elevator = plugin.getActiveLifts()
+				.stream()
+				.findFirst()
+				.orElse(null);
+
+		if (elevator == null) {
+			return;
+		}
+
+		plugin.logDebug(player.getName() + " changed a world while lifting.");
+
+		elevator.removePassengers(Collections.singletonList(player));
+		elevator.removeFreezers(Collections.singletonList(player));
+
+		player.teleport(playerLocation, PlayerTeleportEvent.TeleportCause.PLUGIN);
+		ElevatorExecutor.resetEntityPhysics(player);
+	}
+
 	/**
 	 * If a player quits within an elevator, we have to save a location to teleport the player on next login, so he
 	 * won't fall down the shaft.

--- a/src/main/java/com/minecraftcorp/lift/bukkit/listener/PlayerListener.java
+++ b/src/main/java/com/minecraftcorp/lift/bukkit/listener/PlayerListener.java
@@ -165,7 +165,7 @@ public class PlayerListener implements Listener {
 	}
 
 	@EventHandler
-	public void onPlayerChangedWorldEvent(PlayerChangedWorldEvent event) {
+	public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {
 		Player player = event.getPlayer();
 		Location playerLocation = player.getLocation();
 

--- a/src/main/java/com/minecraftcorp/lift/bukkit/listener/PlayerListener.java
+++ b/src/main/java/com/minecraftcorp/lift/bukkit/listener/PlayerListener.java
@@ -167,7 +167,6 @@ public class PlayerListener implements Listener {
 	@EventHandler
 	public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {
 		Player player = event.getPlayer();
-		Location playerLocation = player.getLocation();
 
 		boolean playerInNoLift = plugin.isInNoLift(player.getUniqueId());
 
@@ -183,7 +182,6 @@ public class PlayerListener implements Listener {
 					elevator.removeFreezers(Collections.singletonList(player));
 				});
 
-		player.teleport(playerLocation, PlayerTeleportEvent.TeleportCause.PLUGIN);
 		ElevatorExecutor.resetEntityPhysics(player);
 	}
 

--- a/src/main/java/com/minecraftcorp/lift/bukkit/listener/PlayerListener.java
+++ b/src/main/java/com/minecraftcorp/lift/bukkit/listener/PlayerListener.java
@@ -174,15 +174,23 @@ public class PlayerListener implements Listener {
 			return;
 		}
 
+		Entity vehicle = player.getVehicle();
 		plugin.getActiveLifts()
 				.stream()
 				.filter(elevator -> elevator.getPassengers().contains(player) || elevator.getFreezers().contains(player))
 				.forEach(elevator -> {
 					elevator.removePassengers(Collections.singletonList(player));
 					elevator.removeFreezers(Collections.singletonList(player));
+					if (vehicle != null) {
+						elevator.removePassengers(Collections.singletonList(vehicle));
+						elevator.removeFreezers(Collections.singletonList(vehicle));
+					}
 				});
 
 		ElevatorExecutor.resetEntityPhysics(player);
+		if (vehicle != null) {
+			ElevatorExecutor.resetEntityPhysics(vehicle);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes an issue where players would teleport to the lift destination coordinates and the lift would start operating when changing worlds while the lift is active.

## What this PR does
- A player who rode the lift and changed worlds will be dismounted.
- A player who rode the lift and changed worlds will be removed from the lift queue.
- The lift will be stopped for a player who changes worlds.

This is my first OSS contribution. I would appreciate your review.